### PR TITLE
Edited Column view to display items saved in localStorage

### DIFF
--- a/js/view/Column.js
+++ b/js/view/Column.js
@@ -22,7 +22,7 @@ export default class Column {
         const itemsFromLocalStorage = KanbanAPI.getItems(id); // a list of item objects [{id: 1, content: '...'}, {}]
         itemsFromLocalStorage.forEach(item => {
             const currentItem = new Item(item.id, item.content);
-            this.elements.items.appendChild(currentItem.elements.root)
+            this.elements.items.appendChild(currentItem.elements.root);
         })
 
         this.elements.addItem.addEventListener("click",

--- a/js/view/Column.js
+++ b/js/view/Column.js
@@ -18,11 +18,18 @@ export default class Column {
 
         this.elements.items.appendChild(topDropZone)
 
-        this.elements.addItem.addEventListener("click", 
-        () => {
-            const newItem = KanbanAPI.insertItem(id, "")
-            this.renderItem(newItem)
-        }
+        // after appending the topDropZone, append items read from localStorage
+        const itemsFromLocalStorage = KanbanAPI.getItems(id); // a list of item objects [{id: 1, content: '...'}, {}]
+        itemsFromLocalStorage.forEach(item => {
+            const currentItem = new Item(item.id, item.content);
+            this.elements.items.appendChild(currentItem.elements.root)
+        })
+
+        this.elements.addItem.addEventListener("click",
+            () => {
+                const newItem = KanbanAPI.insertItem(id, "")
+                this.renderItem(newItem)
+            }
         )
     }
 


### PR DESCRIPTION
- The current view doesn't show items stored in localStorage (if any), even though we have set up in the KanbanAPI to read data from localStorage. 

- I added a few lines to Column.js to 1) get item data from localStorage (using KanbanAPI.getItems(columnId)), 2) create new Items, and 3) append each item.elements.root to column after appending the topDropZone.